### PR TITLE
添加新项目和改进 BistuAuthenticator

### DIFF
--- a/Bistu.Api.Console/Bistu.Api.Console.csproj
+++ b/Bistu.Api.Console/Bistu.Api.Console.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bistu.Api\Bistu.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Bistu.Api.Console/Program.cs
+++ b/Bistu.Api.Console/Program.cs
@@ -1,0 +1,35 @@
+﻿using BistuAuthService;
+using Microsoft.Extensions.Logging;
+using Serilog;
+
+internal class Program
+{
+    public static async Task Main()
+    {
+        Log.Logger = new LoggerConfiguration().WriteTo.Console().CreateLogger();
+        using ILoggerFactory factory = LoggerFactory.Create(builder => builder.AddSerilog());
+        var logger = factory.CreateLogger<BistuAuthenticator>();
+        HttpClientHandler handler = new() { CookieContainer = new() };
+        var httpClient = new HttpClient(handler);
+
+        BistuAuthenticator bistuAuthenticator =
+            new(
+                logger,
+                httpClient,
+                handler.CookieContainer,
+                s =>
+                    System.Diagnostics.Process.Start(
+                        new System.Diagnostics.ProcessStartInfo(s) { UseShellExecute = true }
+                    )
+            );
+        var authStatus = await bistuAuthenticator.AuthorizeAsync();
+        if (!authStatus)
+        {
+            Console.WriteLine("Failed to authenticate.");
+            return;
+        }
+        Console.WriteLine(await bistuAuthenticator.FetchScheduleAsync());
+        await Console.In.ReadLineAsync();
+        await bistuAuthenticator.LogoutAsync();
+    }
+}

--- a/Bistu.Api.Test/Bistu.Api.Test.csproj
+++ b/Bistu.Api.Test/Bistu.Api.Test.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bistu.Api\Bistu.Api.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Bistu.Api.Test/LoginTest.cs
+++ b/Bistu.Api.Test/LoginTest.cs
@@ -1,0 +1,8 @@
+namespace Bistu.Api.Test
+{
+    public class LoginTest
+    {
+        [Fact]
+        public void Test1() { }
+    }
+}

--- a/Bistu.Api.sln
+++ b/Bistu.Api.sln
@@ -5,10 +5,12 @@ VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bistu.Api", "Bistu.Api\Bistu.Api.csproj", "{31BEEA2C-BD29-4D9A-99A8-6C61313ECF15}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bistu.Api.Tests", "Bistu.Api.Tests\Bistu.Api.Tests.csproj", "{2E60396D-E5FD-4B5D-8A8A-07F1AB2AA57F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bistu.Api.Console", "Bistu.Api.Console\Bistu.Api.Console.csproj", "{0C4ED586-DD88-4E99-9312-261A9133D9D2}"
 	ProjectSection(ProjectDependencies) = postProject
 		{31BEEA2C-BD29-4D9A-99A8-6C61313ECF15} = {31BEEA2C-BD29-4D9A-99A8-6C61313ECF15}
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bistu.Api.Test", "Bistu.Api.Test\Bistu.Api.Test.csproj", "{304E5398-C1FE-4FA1-B236-99F6606F2B5E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,10 +22,14 @@ Global
 		{31BEEA2C-BD29-4D9A-99A8-6C61313ECF15}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31BEEA2C-BD29-4D9A-99A8-6C61313ECF15}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31BEEA2C-BD29-4D9A-99A8-6C61313ECF15}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2E60396D-E5FD-4B5D-8A8A-07F1AB2AA57F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2E60396D-E5FD-4B5D-8A8A-07F1AB2AA57F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2E60396D-E5FD-4B5D-8A8A-07F1AB2AA57F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2E60396D-E5FD-4B5D-8A8A-07F1AB2AA57F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C4ED586-DD88-4E99-9312-261A9133D9D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C4ED586-DD88-4E99-9312-261A9133D9D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C4ED586-DD88-4E99-9312-261A9133D9D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C4ED586-DD88-4E99-9312-261A9133D9D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{304E5398-C1FE-4FA1-B236-99F6606F2B5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{304E5398-C1FE-4FA1-B236-99F6606F2B5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{304E5398-C1FE-4FA1-B236-99F6606F2B5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{304E5398-C1FE-4FA1-B236-99F6606F2B5E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
在 `Bistu.Api.sln` 文件中，添加了两个新项目 `Bistu.Api.Console` 和 `Bistu.Api.Test`，并移除了 `Bistu.Api.Tests` 项目的配置。

在 `BistuAuthenticator.cs` 文件中：
* 添加了 `using System.Runtime.CompilerServices;` 引用。
* 添加了 XML 注释。
* 在构造函数中添加了 `Action<string> loginHandler` 参数。
* 修改了 `User-Agent` 的值，从 `"qrLogin"` 改为 `"QrLogin"`。
* 替换了使用 `System.Diagnostics.Process.Start` 打开 URL 的方式，改为使用 `loginHandler`。
* 修改了 QR 码过期时的处理逻辑，从 `break` 改为 `return false`。
* 添加了 `_logger.LogDebug` 日志记录 `_WEU` cookie 的值。
* 修改了 `FetchScheduleAsync` 方法，从 `PostAsync` 改为 `GetAsync`，并添加了 `EnsureSuccessStatusCode` 调用。

添加了 `Bistu.Api.Console.csproj` 文件，配置了一个新的控制台项目，目标框架为 `net8.0`，并引用了 `Serilog` 相关包。

添加了 `Program.cs` 文件，配置了一个控制台应用程序，使用 `Serilog` 进行日志记录，并实现了 BistuAuthenticator 的授权和获取课程表的逻辑。

添加了 `Bistu.Api.Test.csproj` 文件，配置了一个新的测试项目，目标框架为 `net8.0`，并引用了 `xunit` 相关包。

添加了 `LoginTest.cs` 文件，预留了一个简单的测试类 `LoginTest`，包含一个空的测试方法 `Test1`。

这次提交主要是为了添加新的项目和改进 BistuAuthenticator 的功能，嗯。

添加新项目并改进二维码登录处理

在 `Bistu.Api.sln` 文件中，添加了两个新项目 `Bistu.Api.Console` 和 `Bistu.Api.Test`，并移除了 `Bistu.Api.Tests` 项目的配置。

在 `BistuAuthenticator.cs` 文件中：
* 添加了类的 XML 注释。
* 修改了 `User-Agent` 的值，从 `"qrLogin"` 改为 `"QrLogin"`。
* 将二维码登录的处理方式从直接启动浏览器改为通过 `loginHandler` 委托处理。
* 修改了二维码过期时的处理逻辑，从 `break` 改为 `return false`。
* 添加了 `_WEU` cookie 的调试日志。
* 修改了获取课程表的请求方式，从 `PostAsync` 改为 `GetAsync`，并添加了 `EnsureSuccessStatusCode` 方法。

添加了 `Bistu.Api.Console.csproj` 文件，配置了一个新的控制台项目，目标框架为 `net8.0`，并引用了 `Serilog` 相关包和 `Bistu.Api` 项目。

添加了 `Program.cs` 文件，配置了控制台应用的入口点，使用 `Serilog` 进行日志记录，并调用 `BistuAuthenticator` 进行认证和获取课程表。

添加了 `Bistu.Api.Test.csproj` 文件，配置了一个新的测试项目，目标框架为 `net8.0`，并引用了 `xunit` 相关包和 `Bistu.Api` 项目。

添加了 `LoginTest.cs` 文件，定义了一个简单的测试类 `LoginTest`，包含一个空的测试方法 `Test1`。

这次提交主要是为了添加新的控制台和测试项目，并改进二维码登录的处理方式，嗯。